### PR TITLE
Update URLs for integration support pages

### DIFF
--- a/config-sample/integrations.json
+++ b/config-sample/integrations.json
@@ -4,7 +4,7 @@
 		"name": "Basecamp",
 		"auth_type": "oauth2",
 		"image": "/images/logo-basecamp.png",
-		"link": "http://support.toggl.com/basecamp",
+		"link": "https://support.toggl.com/import-and-export/integrations-via-toggl-pipes/integration-with-basecamp",
 		"pipes": [
 			{
 				"id": "users",
@@ -41,7 +41,7 @@
 		"name": "Freshbooks",
 		"auth_type": "oauth1",
 		"image": "/images/logo-freshbooks.png",
-		"link": "http://support.toggl.com/freshbooks",
+		"link": "https://support.toggl.com/import-and-export/integrations-via-toggl-pipes/integration-with-freshbooks-classic",
 		"pipes": [
 			{
 				"id": "users",
@@ -78,7 +78,7 @@
 		"name": "Teamweek",
 		"auth_type": "oauth2",
 		"image": "/images/logo-teamweek.png",
-		"link": "http://support.toggl.com/teamweek",
+		"link": "https://support.toggl.com/import-and-export/integrations-via-toggl-pipes/integration-with-teamweek",
 		"pipes": [
 			{
 				"id": "users",
@@ -108,7 +108,7 @@
 		"name": "Asana",
 		"auth_type": "oauth2",
 		"image": "/images/logo-asana.png",
-		"link": "http://support.toggl.com/asana",
+		"link": "https://support.toggl.com/import-and-export/integrations-via-toggl-pipes/integration-with-asana",
 		"pipes": [
 			{
 				"id": "users",
@@ -138,7 +138,7 @@
 		"name": "Github",
 		"auth_type": "oauth2",
 		"image": "/images/logo-github.png",
-		"link": "https://github.com/toggl/pipes-api",
+		"link": "https://support.toggl.com/import-and-export/integrations-via-toggl-pipes/integration-with-github",
 		"pipes": [
 			{
 				"id": "projects",

--- a/integration_test.go
+++ b/integration_test.go
@@ -25,11 +25,11 @@ func TestWorkspaceIntegrations(t *testing.T) {
 	}
 
 	want := []Integration{
-		{ID: "basecamp", Name: "Basecamp", Link: "http://support.toggl.com/basecamp", Image: "/images/logo-basecamp.png", AuthType: "oauth2"},
-		{ID: "freshbooks", Name: "Freshbooks", Link: "http://support.toggl.com/freshbooks", Image: "/images/logo-freshbooks.png", AuthType: "oauth1"},
-		{ID: "teamweek", Name: "Teamweek", Link: "http://support.toggl.com/teamweek", Image: "/images/logo-teamweek.png", AuthType: "oauth2"},
-		{ID: "asana", Name: "Asana", Link: "http://support.toggl.com/asana", Image: "/images/logo-asana.png", AuthType: "oauth2"},
-		{ID: "github", Name: "Github", Link: "https://github.com/toggl/pipes-api", Image: "/images/logo-github.png", AuthType: "oauth2"},
+		{ID: "basecamp", Name: "Basecamp", Link: "https://support.toggl.com/import-and-export/integrations-via-toggl-pipes/integration-with-basecamp", Image: "/images/logo-basecamp.png", AuthType: "oauth2"},
+		{ID: "freshbooks", Name: "Freshbooks", Link: "https://support.toggl.com/import-and-export/integrations-via-toggl-pipes/integration-with-freshbooks-classic", Image: "/images/logo-freshbooks.png", AuthType: "oauth1"},
+		{ID: "teamweek", Name: "Teamweek", Link: "https://support.toggl.com/import-and-export/integrations-via-toggl-pipes/integration-with-teamweek", Image: "/images/logo-teamweek.png", AuthType: "oauth2"},
+		{ID: "asana", Name: "Asana", Link: "https://support.toggl.com/import-and-export/integrations-via-toggl-pipes/integration-with-asana", Image: "/images/logo-asana.png", AuthType: "oauth2"},
+		{ID: "github", Name: "Github", Link: "https://support.toggl.com/import-and-export/integrations-via-toggl-pipes/integration-with-github", Image: "/images/logo-github.png", AuthType: "oauth2"},
 	}
 
 	if len(integrations) != len(want) {


### PR DESCRIPTION
Update links on the [integrations page](https://toggl.com/app/import/integrations) - currently, clicking "More info" does not go to the correct URLs.

Closes https://github.com/toggl/backend/issues/8422.