### PR TITLE
dont_return_archived

### DIFF
--- a/asana.go
+++ b/asana.go
@@ -11,7 +11,7 @@ import (
 	"github.com/range-labs/go-asana/asana"
 )
 
-const asanaPerPageLimit = 20
+var asanaPerPageLimit uint32 = 100
 
 type AsanaService struct {
 	emptyService

--- a/asana_test.go
+++ b/asana_test.go
@@ -3,11 +3,16 @@
 package main
 
 import (
+	"log"
 	"os"
 	"testing"
 
 	"code.google.com/p/goauth2/oauth"
 )
+
+func resetAsanaLimit() {
+	asanaPerPageLimit = 100
+}
 
 func createAsanaService() Service {
 	s := &AsanaService{}
@@ -48,6 +53,9 @@ func TestAsanaUsers(t *testing.T) {
 }
 
 func TestAsanaProjects(t *testing.T) {
+	defer resetAsanaLimit()
+	asanaPerPageLimit = 10
+
 	s := createAsanaService()
 
 	projects, err := s.Projects()
@@ -55,12 +63,16 @@ func TestAsanaProjects(t *testing.T) {
 		t.Error("error calling projects(), err:", err)
 	}
 
-	if len(projects) <= 20 {
-		t.Error("should get more than 20 project, please create at least 20 project to test pagination")
+	if len(projects) <= 10 {
+		t.Error("should get more than 10 project, please create at least 10 project to test pagination")
 	}
+	log.Print(len(projects))
 }
 
 func TestAsanaTask(t *testing.T) {
+	defer resetAsanaLimit()
+	asanaPerPageLimit = 10
+
 	s := createAsanaService()
 
 	tasks, err := s.Tasks()
@@ -68,8 +80,8 @@ func TestAsanaTask(t *testing.T) {
 		t.Error("error calling tasks(), err: ", err)
 	}
 
-	if len(tasks) <= 20 {
-		t.Error(`should get more than 20 tasks, \
+	if len(tasks) <= 10 {
+		t.Error(`should get more than 10 tasks, \
 please create at least 20 tasks and assign them to a project to test pagination`)
 	}
 }

--- a/src/github.com/range-labs/go-asana/asana/asana.go
+++ b/src/github.com/range-labs/go-asana/asana/asana.go
@@ -137,7 +137,7 @@ type (
 	}
 
 	Filter struct {
-		Archived       bool     `url:"archived"`
+		Archived       bool     `url:"archived,omitempty"`
 		Assignee       int64    `url:"assignee,omitempty"`
 		AssigneeGID    int64    `url:"assignee,omitempty"`
 		Project        int64    `url:"project,omitempty"`


### PR DESCRIPTION
It seems that maybe some errors are related to the great number of request we might be doing...
see:
- https://forum.asana.com/t/the-result-is-too-large-you-should-use-pagination-may-require-specifying-a-workspace/21374/5
- https://forum.asana.com/t/tag-endpoint-not-handling-paginated-request-and-timeout-properly/62729/5

So ~i disable fetching of archived entities~ and I bump the limit per request to 100. Let see if that helps.

Also not that i updated the asna library directly (the users call was not using pagination ~and did a quick hack that filter archived...~) so i dont know maybe if this work we should submit a patch to the creator or fork the library.

I revert the filtering of archived projects because it's a product problem to be honnest