### PR TITLE
9269 (asana project dup) - new flag indicating if service supports client

### DIFF
--- a/basecamp.go
+++ b/basecamp.go
@@ -12,6 +12,7 @@ import (
 )
 
 type BasecampService struct {
+	emptyService
 	workspaceID int
 	*BasecampParams
 	token         oauth.Token
@@ -95,11 +96,6 @@ func (s *BasecampService) Users() ([]*User, error) {
 		users = append(users, &user)
 	}
 	return users, nil
-}
-
-// There are no clients in basecamp
-func (s *BasecampService) Clients() ([]*Client, error) {
-	return nil, nil
 }
 
 // Map basecamp projects to projects

--- a/model.go
+++ b/model.go
@@ -82,6 +82,7 @@ type (
 
 	ProjectsResponse struct {
 		Error    string     `json:"error"`
+		SupportsClient bool `json:"supports_client"`
 		Projects []*Project `json:"projects"`
 	}
 

--- a/project.go
+++ b/project.go
@@ -3,6 +3,7 @@ package main
 type (
 	projectRequest struct {
 		Projects []*Project `json:"projects"`
+		SupportsClient bool `json:"supports_client"`
 	}
 
 	ProjectsImport struct {

--- a/service.go
+++ b/service.go
@@ -88,7 +88,7 @@ func (s *emptyService) setSince(*time.Time)                     {}
 func (s *emptyService) setParams([]byte) error                  { return nil }
 func (s *emptyService) Users() ([]*User, error)                 { return nil, nil }
 func (s *emptyService) Tasks() ([]*Task, error)                 { return nil, nil }
-func (s *emptyService) Clients() ([]*Client, error)             { return nil, nil }
+func (s *emptyService) Clients() ([]*Client, error)             { return nil, fmt.Errorf("%w clients", ErrNotSupported) }
 func (s *emptyService) TodoLists() ([]*Task, error)             { return nil, nil }
 func (s *emptyService) Projects() ([]*Project, error)           { return nil, nil }
 func (s *emptyService) Accounts() ([]*Account, error)           { return nil, nil }


### PR DESCRIPTION
The problem of duplicating projects from Asana relies [on this query](https://github.com/toggl/toggl_api/blob/c45a996aa30acfa3606390817bfaa1b5137542c6/internal/v8/project.go#L504) in `toggl_api`.

The reason is that when loading an existing project by name to sync for the first time, the query takes into account the client ID, matching an existing client or looking for null client in DB if no client param was sent by pipes.

This works well for FreshBooks, for example, which has the Client entity, so projects with or without a related Client can be mapped correctly. But Asana doesn’t have Client, so all projects synced from Asana has no `clientID` param (which is translated to `client_id = 0` in the original query).

This PR adds `SupportsClient` flag in project request indicating whether service supports `Client` entity or not. This flag can then be used by `toggl_api` to proper load projects using the `client_id` or not.

Part of toggl/backend#9269

Needs to be deployed before https://github.com/toggl/toggl_api/pull/1766